### PR TITLE
hash based on type attr instead of class name

### DIFF
--- a/vocode/streaming/models/synthesizer.py
+++ b/vocode/streaming/models/synthesizer.py
@@ -249,7 +249,7 @@ class PollySynthesizerConfig(SynthesizerConfig, type=SynthesizerType.POLLY.value
 
 def __hash__(instance) -> str:
     hash = hashlib.sha256()
-    hash.update(bytes(instance.__class__.__name__, "utf-8"))
+    hash.update(bytes(getattr(instance, "type"), "utf-8"))
     for _, value in vars(instance).items():
         hash.update(bytes(str(value), "utf-8"))
     return hash.hexdigest()


### PR DESCRIPTION
want to use the const "type" attribute instead of the class name, since in some cases we get subclasses and in some cases we get base classes, but the underlying values are otherwise the same