### PR TITLE
Chunk the cached TTS audio

### DIFF
--- a/vocode/streaming/synthesizer/eleven_labs_synthesizer.py
+++ b/vocode/streaming/synthesizer/eleven_labs_synthesizer.py
@@ -51,9 +51,17 @@ class ElevenLabsSynthesizer(BaseSynthesizer[ElevenLabsSynthesizerConfig]):
         self.logger = logger or logging.getLogger(__name__)
 
     async def cached_chunk_generator(
-        self, cached_audio: bytes
+        self,
+        cached_audio: bytes,
+        chunk_size: int,
     ) -> AsyncGenerator[SynthesisResult.ChunkResult, None]:
-        yield SynthesisResult.ChunkResult(cached_audio, True)
+        for i in range(0, len(cached_audio), chunk_size):
+            if i + chunk_size > len(cached_audio):
+                yield SynthesisResult.ChunkResult(cached_audio[i:], True)
+            else:
+                yield SynthesisResult.ChunkResult(
+                    cached_audio[i : i + chunk_size], False
+                )
 
     async def create_speech(
         self,
@@ -152,7 +160,7 @@ class ElevenLabsSynthesizer(BaseSynthesizer[ElevenLabsSynthesizerConfig]):
         # Each of the branches below use the cached audio to generate a response
         if self.experimental_streaming:
             synthesis_result = SynthesisResult(
-                self.cached_chunk_generator(audio_data),
+                self.cached_chunk_generator(audio_data, chunk_size=chunk_size),
                 lambda seconds: self.get_message_cutoff_from_voice_speed(
                     message, seconds, self.words_per_minute
                 ),


### PR DESCRIPTION
https://tenyx.atlassian.net/browse/TEN-312

# Test
Made a call locally. See [Sentry](https://tenyx-ax.sentry.io/discover/sandbox:bf5c72592d114593a6f14c959609da0a/?field=title&field=event.type&field=project&field=user.display&field=timestamp&field=replayId&name=All+Events&project=4504640206340096&query=&sort=-timestamp&statsPeriod=7d&yAxis=count%28%29). All the TTS span should be less than 0.5 seconds now.