### PR TITLE
fix machine detection for vonage

### DIFF
--- a/vocode/streaming/models/telephony.py
+++ b/vocode/streaming/models/telephony.py
@@ -29,7 +29,7 @@ class TwilioConfig(BaseModel):
     record: bool = False
     recording_url: Optional[str] = None
     events_url: Optional[str] = None
-    extra_params: Optional[Dict[str, Any]] = {}
+    extra_params: Optional[Dict[str, Any]] = None
 
 
 class VonageConfig(BaseModel):
@@ -40,6 +40,7 @@ class VonageConfig(BaseModel):
     record: bool = False
     recording_url: Optional[str] = None
     events_url: Optional[str] = None
+    extra_params: Optional[Dict[str, Any]] = None
 
 
 class CallEntity(BaseModel):

--- a/vocode/streaming/telephony/client/twilio_client.py
+++ b/vocode/streaming/telephony/client/twilio_client.py
@@ -44,6 +44,7 @@ class TwilioClient(BaseTelephonyClient):
     ) -> str:
         # TODO: Make this async. This is blocking.
         twiml = self.get_connection_twiml(conversation_id=conversation_id)
+        extra_params = self.get_telephony_config().extra_params or {}
         twilio_call = self.twilio_client.calls.create(
             twiml=twiml.body.decode("utf-8"),
             to=to_phone,
@@ -53,7 +54,7 @@ class TwilioClient(BaseTelephonyClient):
             recording_status_callback=recording_url,
             status_callback=events_url,
             status_callback_event=["initiated", "ringing", "answered", "completed"],
-            **self.get_telephony_config().extra_params,
+            **extra_params,
         )
         _redis_client.setex(
             f"twilio_sid_{twilio_call.sid}", _ttl_in_seconds, conversation_id

--- a/vocode/streaming/telephony/client/vonage_client.py
+++ b/vocode/streaming/telephony/client/vonage_client.py
@@ -83,6 +83,7 @@ class VonageClient(BaseTelephonyClient):
         events_url: Optional[str] = None,
         digits: Optional[str] = None,
     ) -> str:  # identifier of the call on the telephony provider
+        extra_params = self.get_telephony_config().extra_params or {}
         vonage_call_uuid = await self.create_vonage_call(
             to_phone,
             from_phone,
@@ -91,6 +92,7 @@ class VonageClient(BaseTelephonyClient):
             ),
             digits,
             event_urls=[events_url],
+            **extra_params,
         )
         _redis_client.setex(
             f"vonage_uuid_{vonage_call_uuid}", _ttl_in_seconds, conversation_id


### PR DESCRIPTION
The machine detection was not working for Vonage. It's because we don't pass the `extra_params` to `create_vonage_call`. This PR should fix it.